### PR TITLE
Allow patterns to match filenames starting with a period, not explicitly have a period

### DIFF
--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -167,7 +167,7 @@ load = ->
         filePath = path.relative relativizePath, filePath
       minimatch = require "minimatch" if not minimatch
       for pattern in settings.ignore
-        return true if minimatch filePath, pattern, { matchBase: true }
+        return true if minimatch filePath, pattern, { matchBase: true, dot: true }
       return false
 
     if transport


### PR DESCRIPTION
Hi.
This change is to allow to ignore file starting with a period when sync, patterns don't explicitly have a period.
dot is minimatch's option. https://github.com/isaacs/minimatch#dot