### PR TITLE
add option to not show status bar tile if remote sync isn’t configured

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -5,6 +5,11 @@ module.exports =
       default: false
       title: 'Log to console'
       description: 'Log messages to the console instead of the status view at the bottom of the window'
+    alwaysShowInStatusBar:
+      type: 'boolean'
+      default: true
+      title: 'Always show status bar indicator'
+      description: 'Deselect to hide status for projects with no Remote Sync configuration.'
     difftoolCommand:
       type: 'string'
       default: ''

--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -36,9 +36,12 @@ module.exports =
 
     fs.exists configPath, (exists) ->
       if exists
+        statusView.attach()
         load()
       else
-        statusView.update "question", "Couldn't find config."
+        if atom.config.get("remote-sync.alwaysShowInStatusBar")
+          statusView.attach()
+          statusView.update "question", "Couldn't find config."
 
     atom.commands.add 'atom-workspace', 'remote-sync:download-all', ->
       return if checkSetting()

--- a/lib/view/StatusView.coffee
+++ b/lib/view/StatusView.coffee
@@ -5,20 +5,25 @@ class StatusView extends View
   @content: ->
     @a ' Sync'
 
+  @attached = false
+
   initialize: ->
     @on 'click', ->
       atom.commands.dispatch atom.views.getView(atom.workspace), 'remote-sync:configure'
       false
-    @attach()
+    if atom.config.get("remote-sync.alwaysShowInStatusBar")
+      @attach()
 
   attach: =>
     statusBar = atom.views.getView(atom.workspace).querySelector('.status-bar')
     if statusBar
       statusBar.addLeftTile item: this
+      @attached = true
     else
       @subscribe(atom.packages.once('activated', @attach))
 
   update: (iconName, tips, text) =>
-    @element.className = "inline-block icon icon-#{iconName}" if iconName
-    @setTooltip(if tips then tips + " Click to configure." else "Click to configure.")
-    @text(if text then " Sync: " + text else " Sync")
+    if @attached
+      @element.className = "inline-block icon icon-#{iconName}" if iconName
+      @setTooltip(if tips then tips + " Click to configure." else "Click to configure.")
+      @text(if text then " Sync: " + text else " Sync")


### PR DESCRIPTION
Remote Sync is great, but I only have one project set up for sync-ing and the "Click to Configure" tile is showing up in all of my projects.  This PR seeks to hide the status bar item for projects w/o a configuration for Remote Sync.

This is my first attempt at hacking Atom and I would love any comments or suggestions.

Notes:
  1. I think that this requires the project to be reopened to hide (or show, if Sync gets configured)
  2. If Sync *is* configured for a project, the status bar item is missing the icon image for a second when the project is first opened.  I didn't know how to track that down.

Thanks!