### PR TITLE
Add atomic write support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Create file `.remote-sync.json` in your project root with these settings:
 * `target` — Target directory on remote host
 * `ignore` — Array of [minimatch](https://github.com/isaacs/minimatch) patterns of files to ignore
 * `uploadOnSave` — Whether or not to upload the current file when saved, default: false
+* `useAtomicWrites` — Upload file using a temporary filename before moving to its final location (only used for SCP), default: false
 * `uploadMirrors` — transport mirror config array when upload
 
 SCP example:

--- a/lib/transports/ScpTransport.coffee
+++ b/lib/transports/ScpTransport.coffee
@@ -27,19 +27,27 @@ class ScpTransport
 
       end = @logger.log "Upload: #{localFilePath} to #{targetFilePath} ..."
 
-      c.sftp (err, sftp) ->
+      c.sftp (err, sftp) =>
         return errorHandler err if err
 
-        c.exec "mkdir -p \"#{path.dirname(targetFilePath)}\"", (err) ->
+        c.exec "mkdir -p \"#{path.dirname(targetFilePath)}\"", (err) =>
           return errorHandler err if err
 
-          sftp.fastPut localFilePath, targetFilePath, (err) ->
+          uploadFilePath = if @settings.useAtomicWrites then "#{targetFilePath}.temp" else "#{targetFilePath}"
+
+          sftp.fastPut localFilePath, uploadFilePath, (err) =>
             return errorHandler err if err
 
-            end()
-
             sftp.end()
-            callback()
+
+            if @settings.useAtomicWrites
+              c.exec "cp \"#{uploadFilePath}\" \"#{targetFilePath}\"; rm \"#{uploadFilePath}\"", (err) ->
+                return errorHandler err if err
+                end()
+                callback()
+            else
+              end()
+              callback()
 
   download: (targetFilePath, localFilePath, callback) ->
     if not localFilePath

--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -46,8 +46,13 @@ class ConfigView extends View
       @div class: 'block', outlet: 'ftpPasswordBlock', style: 'display:none', =>
         @label 'Password'
 
-      @label " uploadOnSave", =>
-        @input type: 'checkbox', outlet: 'uploadOnSave'
+      @div =>
+        @label " uploadOnSave", =>
+          @input type: 'checkbox', outlet: 'uploadOnSave'
+
+      @div =>
+        @label " useAtomicWrites", =>
+          @input type: 'checkbox', outlet: 'useAtomicWrites'
 
       @div class: 'block pull-right', =>
         @button class: 'inline-block-tight btn', outlet: 'cancelButton', click: 'close', 'Cancel'
@@ -91,6 +96,7 @@ class ConfigView extends View
       $(editor).view().setText(@host[dataName] or "")
 
     @uploadOnSave.prop('checked', @host.uploadOnSave)
+    @useAtomicWrites.prop('checked', @host.useAtomicWrites)
     $(":contains('"+@host.transport.toUpperCase()+"')", @transportGroup).click() if @host.transport
     if @host.transport is "scp"
       $('.btn-group .btn', @authenticationButtonsBlock).each (i, btn)=>
@@ -107,6 +113,7 @@ class ConfigView extends View
 
   confirm: ->
     @host.uploadOnSave = @uploadOnSave.prop('checked')
+    @host.useAtomicWrites = @useAtomicWrites.prop('checked')
     @find(".editor").each (i, editor)=>
       dataName = $(editor).prev().text().split(" ")[0].toLowerCase()
       view = $(editor).view()


### PR DESCRIPTION
Atomic writes help when server-side processes are prone to reading the file too early (during the upload process). Things like auto-compilation watchers (gulp etc.) can be thrown off by direct scp operations.

I'm not sure if this is also possible for FTP, but as I only use scp that's all I have implemented for now.