### PR TITLE
Remote file and folder delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Create file `.remote-sync.json` in your project root with these settings:
 * `ignore` — Array of [minimatch](https://github.com/isaacs/minimatch) patterns of files to ignore
 * `uploadOnSave` — Whether or not to upload the current file when saved, default: false
 * `uploadMirrors` — transport mirror config array when upload
+* `deleteLocal` - whether or not to delete the local file / folder after remote delete
 
 SCP example:
 ```json

--- a/index.coffee
+++ b/index.coffee
@@ -6,13 +6,13 @@ $ = null
 
 getEventPath = (e)->
   $ ?= require('atom-space-pen-views').$
-  
+
   target = $(e.target).closest('.file, .directory, .tab')[0]
   target ?= atom.workspace.getActiveTextEditor()
-  
+
   fullPath = target?.getPath?()
   return [] unless fullPath
-  
+
   [projectPath, relativePath] = atom.project.relativizePath(fullPath)
   return [projectPath, fullPath]
 
@@ -27,7 +27,7 @@ initProject = (projectPaths)->
   for projectPath in disposes
     projectDict[projectPath].dispose()
     delete projectDict[projectPath]
-  
+
   for projectPath in projectPaths
     try
         projectPath = fs.realpathSync(projectPath)
@@ -37,14 +37,14 @@ initProject = (projectPaths)->
     RemoteSync ?= require "./lib/RemoteSync"
     obj = RemoteSync.create(projectPath)
     projectDict[projectPath] = obj if obj
-  
+
 handleEvent = (e, cmd)->
   [projectPath, fullPath] = getEventPath(e)
   return unless projectPath
-  
+
   projectObj = projectDict[fs.realpathSync(projectPath)]
   projectObj[cmd]?(fs.realpathSync(fullPath))
-  
+
 reload = (projectPath)->
   projectDict[projectPath]?.dispose()
   projectDict[projectPath] = RemoteSync.create(projectPath)
@@ -52,7 +52,7 @@ reload = (projectPath)->
 configure = (e)->
   [projectPath] = getEventPath(e)
   return unless projectPath
-  
+
   projectPath = fs.realpathSync(projectPath)
   RemoteSync ?= require "./lib/RemoteSync"
   RemoteSync.configure projectPath, -> reload(projectPath)
@@ -72,17 +72,19 @@ module.exports =
     configFileName:
       type: 'string'
       default: '.remote-sync.json'
-      
+
   activate: (state) ->
     projectDict = {}
     initProject(atom.project.getPaths())
-    
+
     CompositeDisposable ?= require('atom').CompositeDisposable
     disposables = new CompositeDisposable
-    
+
     disposables.add atom.commands.add('atom-workspace', {
       'remote-sync:upload-folder': (e)-> handleEvent(e, "uploadFolder")
       'remote-sync:upload-file': (e)-> handleEvent(e, "uploadFile")
+      'remote-sync:delete-file': (e)-> handleEvent(e, "deleteFile")
+      'remote-sync:delete-folder': (e)-> handleEvent(e, "deleteFile")
       'remote-sync:download-file': (e)-> handleEvent(e, "downloadFile")
       'remote-sync:download-folder': (e)-> handleEvent(e, "downloadFolder")
       'remote-sync:diff-file': (e)-> handleEvent(e, "diffFile")
@@ -90,33 +92,33 @@ module.exports =
       'remote-sync:upload-git-change': (e)-> handleEvent(e, "uploadGitChange")
       'remote-sync:configure': configure
     })
-    
+
     disposables.add atom.project.onDidChangePaths (projectPaths)->
       initProject(projectPaths)
-    
+
     disposables.add atom.workspace.observeTextEditors (editor) ->
       onDidSave = editor.onDidSave (e) ->
         fullPath = e.path
         [projectPath, relativePath] = atom.project.relativizePath(fullPath)
         return unless projectPath
-        
+
         projectPath = fs.realpathSync(projectPath)
         projectObj = projectDict[projectPath]
         return unless projectObj
-        
+
         if fs.realpathSync(fullPath) == fs.realpathSync(projectObj.configPath)
           projectObj = reload(projectPath)
-        
+
         return unless projectObj.host.uploadOnSave
         projectObj.uploadFile(fs.realpathSync(fullPath))
-        
-      
+
+
       onDidDestroy = editor.onDidDestroy ->
         disposables.remove onDidSave
         disposables.remove onDidDestroy
         onDidDestroy.dispose()
         onDidSave.dispose()
-        
+
       disposables.add onDidSave
       disposables.add onDidDestroy
 

--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -25,15 +25,15 @@ getLogger = ->
 class RemoteSync
   constructor: (@projectPath, @configPath) ->
     Host ?= require './model/host'
-    
+
     @host = new Host(@configPath)
     @initIgnore(@host)
-  
+
   initIgnore: (host)->
     ignore = host.ignore?.split(",")
     host.isIgnore = (filePath, relativizePath) =>
       return false unless ignore
-      
+
       relativizePath = @projectPath unless relativizePath
       filePath = path.relative relativizePath, filePath
 
@@ -41,28 +41,42 @@ class RemoteSync
       for pattern in ignore
         return true if minimatch filePath, pattern, { matchBase: true, dot: true }
       return false
-      
+
   isIgnore: (filePath, relativizePath)->
     return @host.isIgnore(filePath, relativizePath)
-    
+
   dispose: ->
     if @transport
       @transport.dispose()
       @transport = null
 
+  deleteFile: (filePath) ->
+    return if @isIgnore(filePath)
+
+    if not uploadCmd
+      UploadListener = require "./UploadListener"
+      uploadCmd = new UploadListener getLogger()
+
+    uploadCmd.handleDelete(filePath, @getTransport())
+    for t in @getUploadMirrors()
+      uploadCmd.handleDelete(filePath, t)
+
+    if @host.deleteLocal
+      fs.removeSync(filePath)
+
   downloadFolder: (localPath, targetPath, callback)->
     DownloadCmd ?= require './commands/DownloadAllCommand'
     DownloadCmd.run(getLogger(), @getTransport(),
                                 localPath, targetPath, callback)
-  
+
   downloadFile: (localPath)->
     realPath = path.relative(@projectPath, localPath)
     realPath = path.join(@host.target, realPath).replace(/\\/g, "/")
     @getTransport().download(realPath)
-    
+
   uploadFile: (filePath) ->
     return if @isIgnore(filePath)
-    
+
     if not uploadCmd
       UploadListener = require "./UploadListener"
       uploadCmd = new UploadListener getLogger()
@@ -74,7 +88,7 @@ class RemoteSync
   uploadFolder: (dirPath)->
     fs.traverseTree dirPath, @uploadFile.bind(@), =>
       return not @isIgnore(dirPath)
-  
+
   uploadGitChange: (dirPath)->
     repos = atom.project.getRepositories()
     curRepo = null
@@ -85,15 +99,15 @@ class RemoteSync
         curRepo = repo
         break
     return unless curRepo
-    
+
     isChangedPath = (path)->
       status = curRepo.getCachedPathStatus(path)
       return curRepo.isStatusModified(status) or curRepo.isStatusNew(status)
-      
+
     fs.traverseTree dirPath, (path)=>
       @uploadFile(path) if isChangedPath(path)
     , (path)=> return not @isIgnore(path)
-  
+
   createTransport: (host)->
     if host.transport is 'scp' or host.transport is 'sftp'
       ScpTransport ?= require "./transports/ScpTransport"
@@ -129,13 +143,13 @@ class RemoteSync
 
     @getTransport().download realPath, targetPath, =>
       @diff localPath, targetPath
-  
+
   diffFolder: (localPath)->
     os = require "os" if not os
     targetPath = path.join os.tmpDir(), "remote-sync"
     @downloadFolder localPath, targetPath, =>
       @diff localPath, targetPath
-  
+
   diff: (localPath, targetPath) ->
     targetPath = path.join(targetPath, path.relative(@projectPath, localPath))
     diffCmd = atom.config.get('remote-sync.difftoolCommand')
@@ -146,18 +160,18 @@ class RemoteSync
        Command error: #{err}
        command: #{diffCmd} #{localPath} #{targetPath}
       """
-    
-module.exports = 
+
+module.exports =
   create: (projectPath)->
     configPath = path.join projectPath, atom.config.get('remote-sync.configFileName')
     return unless fs.existsSync configPath
     return new RemoteSync(projectPath, configPath)
-  
+
   configure: (projectPath, callback)->
     HostView ?= require './view/host-view'
     Host ?= require './model/host'
     EventEmitter ?= require("events").EventEmitter
-    
+
     emitter = new EventEmitter()
     emitter.on "configured", callback
 

--- a/lib/UploadListener.coffee
+++ b/lib/UploadListener.coffee
@@ -13,6 +13,19 @@ class UploadListener
       localFilePath: localFilePath
       transport: transport
 
+  handleDelete: (localFilePath, transport) ->
+    if not @queueDelete
+      async = require "async" if not async
+      @queueDelete = async.queue(@deleteFile.bind(@), 1)
+
+    @queueDelete.push
+      localFilePath: localFilePath
+      transport: transport
+
+  deleteFile: (task, callback) ->
+    {localFilePath, transport} = task
+    transport.delete localFilePath, callback
+
   uploadFile: (task, callback) ->
     {localFilePath, transport} = task
     transport.upload localFilePath, callback

--- a/lib/transports/FtpTransport.coffee
+++ b/lib/transports/FtpTransport.coffee
@@ -13,6 +13,27 @@ class FtpTransport
         @logger.error err if err
       @connection = null
 
+  delete: (localFilePath, callback) ->
+    targetFilePath = path.join(@settings.target,
+                                path.relative(@projectPath, localFilePath))
+                                .replace(/\\/g, "/")
+
+    errorHandler = (err) =>
+      @logger.error err
+      callback()
+
+    @_getConnection (err, c) =>
+      return errorHandler err if err
+
+      end = @logger.log "Remote delete: #{targetFilePath} ..."
+
+      c.delete targetFilePath, (err) ->
+        return errorHandler err if err
+
+        end()
+
+        callback()
+
   upload: (localFilePath, callback) ->
     targetFilePath = path.join(@settings.target,
                                 path.relative(@projectPath, localFilePath))

--- a/lib/transports/ScpTransport.coffee
+++ b/lib/transports/ScpTransport.coffee
@@ -12,6 +12,30 @@ class ScpTransport
       @connection.end()
       @connection = null
 
+  delete: (localFilePath, callback) ->
+    targetFilePath = path.join(@settings.target,
+                          path.relative(@projectPath, localFilePath))
+                          .replace(/\\/g, "/")
+
+    errorHandler = (err) =>
+      @logger.error err
+      callback()
+
+    @_getConnection (err, c) =>
+      return errorHandler err if err
+
+      end = @logger.log "Remote delete: #{targetFilePath} ..."
+
+      c.sftp (err, sftp) ->
+        return errorHandler err if err
+
+        c.exec "rm -rf \"#{targetFilePath}\"", (err) ->
+          return errorHandler err if err
+
+          end()
+          sftp.end()
+          callback()
+
   upload: (localFilePath, callback) ->
     fs = require "fs" if not fs
     targetFilePath = path.join(@settings.target,

--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -46,8 +46,12 @@ class ConfigView extends View
       @div class: 'block', outlet: 'ftpPasswordBlock', style: 'display:none', =>
         @label 'Password'
 
-      @label " uploadOnSave", =>
-        @input type: 'checkbox', outlet: 'uploadOnSave'
+      @div class:'block', =>
+        @label " uploadOnSave", =>
+          @input type: 'checkbox', outlet: 'uploadOnSave'
+
+      @label " Delete local file/folder upon remote delete", =>
+        @input type: 'checkbox', outlet: 'deleteLocal'
 
       @div class: 'block pull-right', =>
         @button class: 'inline-block-tight btn', outlet: 'cancelButton', click: 'close', 'Cancel'
@@ -91,6 +95,7 @@ class ConfigView extends View
       $(editor).view().setText(@host[dataName] or "")
 
     @uploadOnSave.prop('checked', @host.uploadOnSave)
+    @deleteLocal.prop('checked', @host.deleteLocal)
     $(":contains('"+@host.transport.toUpperCase()+"')", @transportGroup).click() if @host.transport
     if @host.transport is "scp"
       $('.btn-group .btn', @authenticationButtonsBlock).each (i, btn)=>
@@ -107,6 +112,7 @@ class ConfigView extends View
 
   confirm: ->
     @host.uploadOnSave = @uploadOnSave.prop('checked')
+    @host.deleteLocal = @deleteLocal.prop('checked')
     @find(".editor").each (i, editor)=>
       dataName = $(editor).prev().text().split(" ")[0].toLowerCase()
       view = $(editor).view()

--- a/menus/context.cson
+++ b/menus/context.cson
@@ -5,9 +5,10 @@
       {label: 'Upload File', command: 'remote-sync:upload-file'}
       {label: 'Download File', command: 'remote-sync:download-file'}
       {label: 'Diff File', command: 'remote-sync:diff-file'}
+      {label: 'Delete File', command: 'remote-sync:delete-file'}
     ]
   ]
-  
+
   '.tree-view.full-menu .header.list-item':[
     label: 'Remote Sync',
     submenu:[
@@ -16,5 +17,6 @@
       {label: 'Upload Folder Change', command: 'remote-sync:upload-git-change'}
       {label: 'Download Folder', command: 'remote-sync:download-folder'}
       {label: 'Diff Folder', command: 'remote-sync:diff-folder'}
+      {label: 'Delete Folder', command: 'remote-sync:delete-folder'}
     ]
   ]


### PR DESCRIPTION
* adds ability to delete remote files and folders
* adds a configuration option to allow for an automatic local deletion after the remote deletion is done

Please note that unlike the "Delete" function from the FileTree package that sends files to Trash, this delete is permanent. Let me know if you would like it to behave more like the function in the Tree package.