### PR TITLE
Windows "useAgent" pageant support

### DIFF
--- a/lib/transports/ScpTransport.coffee
+++ b/lib/transports/ScpTransport.coffee
@@ -152,11 +152,11 @@ class ScpTransport
         if /windows/i.test process.env['OS']
           process.env['SSH_AUTH_SOCK'] or "pageant"
         else
-          process.env['SSH_AUTH_SOCK']
+          process.env['SSH_AUTH_SOCK'] or null
       when typeof useAgent is "string"
         useAgent
       else
-        ""
+        null
     
     connection.connect
       host: hostname

--- a/lib/transports/ScpTransport.coffee
+++ b/lib/transports/ScpTransport.coffee
@@ -146,7 +146,18 @@ class ScpTransport
       privateKey = fs.readFileSync keyfile
     else
       privateKey = null
-
+      
+    agent = switch
+      when useAgent is true
+        if /windows/i.test process.env['OS']
+          process.env['SSH_AUTH_SOCK'] or "pageant"
+        else
+          process.env['SSH_AUTH_SOCK']
+      when typeof useAgent is "string"
+        useAgent
+      else
+        ""
+    
     connection.connect
       host: hostname
       port: port
@@ -154,7 +165,6 @@ class ScpTransport
       password: password
       privateKey: privateKey
       passphrase: passphrase
-      readyTimeout: readyTimeout
-      agent: if useAgent then process.env['SSH_AUTH_SOCK'] else null
+      agent: agent
 
     @connection = connection

--- a/lib/transports/ScpTransport.coffee
+++ b/lib/transports/ScpTransport.coffee
@@ -165,6 +165,7 @@ class ScpTransport
       password: password
       privateKey: privateKey
       passphrase: passphrase
+      readyTimeout: readyTimeout
       agent: agent
 
     @connection = connection


### PR DESCRIPTION
Defaults windows connections using the `useAgent` option to `pageant` (A windows SSH key agent) when no `process.env['SSH_AUTH_SOCK']` is available. Also allows the `useAgent` option to be passed in if it's a string.

There is a windows env check so that when creating a config you only need to click "useAgent" instead of manually editing the file to add "pageant" as the "useAgent" value.

Fixes #210, related to #200 