### PR TITLE
Monitor file - Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This package provides functionality for:
 - Uploading changes automatically when you save a file
 - Uploading/downloading files to/from the server
 - Displaying diffs between the local and remote files with your favourite diff tool
-- Monitor files for external change and automatically upload
+- Monitoring files for external change and automatically upload
 - set difftoolCommand in AtomSettingView of `remote-sync` -- The path to your diff tool executable
 
 Currently, both SCP/SFTP and FTP are supported.

--- a/index.coffee
+++ b/index.coffee
@@ -96,6 +96,7 @@ module.exports =
       'remote-sync:diff-folder': (e)-> handleEvent(e, "diffFolder")
       'remote-sync:upload-git-change': (e)-> handleEvent(e, "uploadGitChange")
       'remote-sync:monitor-file': (e)-> handleEvent(e, "monitorFile")
+      'remote-sync:mointor-files-list': (e)-> handleEvent(e,"monitorFilesList")
       'remote-sync:configure': configure
     })
 

--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -143,6 +143,18 @@ class RemoteSync
         list_item = icon_file.parentNode
         list_item.classList.add monitorClass
 
+  monitorFilesList: ()->
+    files        = ""
+    watchedPaths = watcher.getWatched()
+    for k,v of watchedPaths
+      for file in watchedPaths[k]
+        files += file+"<br/>"
+    if files != ""
+      atom.notifications.addInfo "remote-sync: Currently watching:<br/>*"+files+"*"
+    else
+      atom.notifications.addWarning "remote-sync: Currently watching any files"
+
+
   uploadGitChange: (dirPath)->
     repos = atom.project.getRepositories()
     curRepo = null

--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -108,19 +108,25 @@ class RemoteSync
       return not @isIgnore(dirPath)
 
   monitorFile: (dirPath)->
+    fileName = @.monitorFileName(dirPath)
     if dirPath not in MonitoredFiles
       MonitoredFiles.push dirPath
-      watcher.add(dirPath);
+      watcher.add(dirPath)
+      atom.notifications.addInfo "remote-sync: Watching file - *"+fileName+"*"
       _this = @
       watcher.on('change', (path) ->
         _this.uploadFile(path)
-      ).on 'unlink', (path) ->
-        log 'File', path, 'has been removed'
+      )
     else
       watcher.unwatch(dirPath)
-      index = MonitoredFiles.indexOf(dirPath);
+      index = MonitoredFiles.indexOf(dirPath)
       MonitoredFiles.splice(index, 1)
+      atom.notifications.addInfo "remote-sync: Unwatching file - *"+fileName+"*"
     @.monitorStyles()
+
+  monitorFileName: (dirPath)->
+    file = /[^/]*$/.exec(dirPath)[0];
+    return file
 
   monitorStyles: ()->
     monitorClass  = 'file-monitoring'
@@ -133,8 +139,9 @@ class RemoteSync
     for file in MonitoredFiles
       file_name = file.replace(/(['"])/g, "\\$1");
       icon_file = document.querySelector '[data-path="'+file_name+'"]'
-      list_item = icon_file.parentNode
-      list_item.classList.add monitorClass
+      if icon_file != null
+        list_item = icon_file.parentNode
+        list_item.classList.add monitorClass
 
   uploadGitChange: (dirPath)->
     repos = atom.project.getRepositories()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-sync",
-  "version": "3.5.0",
+  "version": "4.0.1",
   "description": "Upload your files to remote host after every change. Both SCP/SFTP and FTP are supported.",
   "license": "MIT",
   "repository": "https://github.com/yongkangchen/remote-sync",

--- a/styles/monitor.less
+++ b/styles/monitor.less
@@ -1,10 +1,10 @@
-.file-monitoring{
-  &:after{
-    content: "M";
-    width: 25px;
-    height: 25px;
-    color: orange;
-    position: absolute;
-    right: 0px;
-  }
+.file-monitoring {
+    &:after {
+        content: "M";
+        width: 25px;
+        height: 25px;
+        color: orange;
+        position: absolute;
+        left: 10px;
+    }
 }


### PR DESCRIPTION
**Fixes**:

#262 - Should no longer show an error message when toggling on a windows device
#263 - Removed watch for delete of file which called missing log

**Added**:

- [x] Added atom notifications to give information when toggling a file
- [x] Added list all monitored. To access <kbd>cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> and find `Remote Sync: Mointor Files List`