### PR TITLE
Define files to watch per project

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Create file `.remote-sync.json` in your project root with these settings:
 - `target` -- Target directory on remote host
 - `source` -- Source directory relative to project root
 - `ignore` -- Array of [minimatch](https://github.com/isaacs/minimatch) patterns of files to ignore
+- `watch` -- Array of files (relative to project root - starting with "/") to watch for changes
 - `uploadOnSave` -- Whether or not to upload the current file when saved, default: false
 - `useAtomicWrites` -- Upload file using a temporary filename before moving to its final location (only used for SCP), default: false
 - `uploadMirrors` -- transport mirror config array when upload
@@ -48,6 +49,10 @@ SCP example:
   "ignore": [
     ".remote-sync.json",
     ".git/**"
+  ],
+  "watch":[
+    "/css/styles.css",
+    "/index.html"
   ]
 }
 ```
@@ -65,6 +70,10 @@ SCP `useAgent` example:
   "ignore": [
     ".remote-sync.json",
     ".git/**"
+  ],
+  "watch":[
+    "/css/styles.css",
+    "/index.html"
   ]
 }
 ```
@@ -82,6 +91,10 @@ FTP example:
   "ignore": [
     ".remote-sync.json",
     ".git/**"
+  ],
+  "watch":[
+    "/css/styles.css",
+    "/index.html"
   ]
 }
 ```
@@ -101,6 +114,10 @@ Upload mirrors example:
   "ignore": [
     ".remote-sync.json",
     ".git/**"
+  ],
+  "watch":[
+    "/css/styles.css",
+    "/index.html"
   ],
   "uploadMirrors":[
     {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This package provides functionality for:
 - Uploading/downloading files to/from the server
 - Displaying diffs between the local and remote files with your favourite diff tool
 - Monitoring files for external change and automatically upload
+- Define files to be watched for automatic monitoring when project loads
 - set difftoolCommand in AtomSettingView of `remote-sync` -- The path to your diff tool executable
 
 Currently, both SCP/SFTP and FTP are supported.

--- a/index.coffee
+++ b/index.coffee
@@ -69,6 +69,11 @@ module.exports =
       default: false
       title: 'Hide log panel after transferring'
       description: 'Hides the status view at the bottom of the window after the transfer operation is done'
+    monitorFileAnimation:
+      type: 'boolean'
+      default: true
+      title: 'Monitor file animation'
+      description: 'Toggles the pulse animation for a monitored file'
     difftoolCommand:
       type: 'string'
       default: ''

--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -38,6 +38,7 @@ class RemoteSync
     if watchFiles?
       @initAutoFileWatch(@projectPath)
     @initIgnore(@host)
+    @initMonitor()
 
   initIgnore: (host)->
     ignore = host.ignore?.split(",")
@@ -110,6 +111,23 @@ class RemoteSync
   uploadFolder: (dirPath)->
     fs.traverseTree dirPath, @uploadFile.bind(@), =>
       return not @isIgnore(dirPath)
+
+  initMonitor: ()->
+    _this = @
+    setTimeout ->
+      MutationObserver = window.MutationObserver or window.WebKitMutationObserver
+      observer = new MutationObserver((mutations, observer) ->
+        _this.monitorStyles()
+        return
+      )
+
+      targetObject = document.querySelector '.tree-view'
+      if targetObject != null
+        observer.observe targetObject,
+          subtree: true
+          attributes: false
+          childList: true
+    , 250
 
   monitorFile: (dirPath, toggle = true, notifications = true)->
     return if !@fileExists(dirPath)

--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -125,11 +125,12 @@ class RemoteSync
     @.monitorStyles()
 
   monitorFileName: (dirPath)->
-    file = /[^/]*$/.exec(dirPath)[0];
+    file = dirPath.split('\\').pop().split('/').pop() # /[^/]*$/.exec(dirPath)[0];
     return file
 
   monitorStyles: ()->
     monitorClass  = 'file-monitoring'
+    pulseClass    = 'pulse'
     monitored     = document.querySelectorAll '.'+monitorClass
 
     if monitored != null and monitored.length != 0
@@ -138,10 +139,13 @@ class RemoteSync
 
     for file in MonitoredFiles
       file_name = file.replace(/(['"])/g, "\\$1");
+      file_name = file.replace(/\\/g, '\\\\');
       icon_file = document.querySelector '[data-path="'+file_name+'"]'
       if icon_file != null
         list_item = icon_file.parentNode
         list_item.classList.add monitorClass
+        if atom.config.get("remote-sync.monitorFileAnimation")
+          list_item.classList.add pulseClass
 
   monitorFilesList: ()->
     files        = ""

--- a/lib/model/host.coffee
+++ b/lib/model/host.coffee
@@ -16,6 +16,7 @@ class Host
     @port?= ""
     @port = @port.toString()
     @ignore = @ignore.join(", ") if @ignore
+    @watch  = @watch.join(", ") if @watch
 
   saveJSON: ->
     configPath = @configPath
@@ -27,6 +28,10 @@ class Host
     @ignore?= ".remote-sync.json,.git/**"
     @ignore = @ignore.split(',')
     @ignore = (val.trim() for val in @ignore when val)
+
+    @watch  ?= ""
+    @watch   = @watch.split(',')
+    @watch   = (val.trim() for val in @watch when val)
 
     @transport?="scp"
 

--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -46,6 +46,9 @@ class ConfigView extends View
       @div class: 'block', outlet: 'ftpPasswordBlock', style: 'display:none', =>
         @label 'Password'
 
+      @label 'Watch automatically'
+      @subview 'watch', new TextEditorView(mini: true, placeholderText: "Files that will be automatically watched on project open")
+
       @div =>
         @label " uploadOnSave", =>
           @input type: 'checkbox', outlet: 'uploadOnSave'

--- a/styles/monitor.less
+++ b/styles/monitor.less
@@ -1,10 +1,36 @@
+// The ui-variables file is provided by base themes provided by Atom.
+//
+// See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
+// for a full listing of what's available.
+@import "ui-variables";
 .file-monitoring {
     &:after {
         content: "M";
-        width: 25px;
-        height: 25px;
-        color: orange;
+        width: 20px;
+        height: 20px;
+        color: @text-color-success;
         position: absolute;
         left: 10px;
+        text-align: center;
+        border-radius: 50%;
+        line-height: 20px;
+    }
+    &.pulse {
+        &:after {
+            -webkit-animation-name: greenPulse;
+            -webkit-animation-duration: 2s;
+            -webkit-animation-iteration-count: infinite;
+        }
+    }
+}
+@-webkit-keyframes greenPulse {
+    from {
+        -webkit-box-shadow: 0 0 9px transparentize(@text-color-success,0.8);
+    }
+    50% {
+        -webkit-box-shadow: 0 0 18px darken(@text-color-success,10%);
+    }
+    to {
+        -webkit-box-shadow: 0 0 9px transparentize(@text-color-success,0.8);
     }
 }


### PR DESCRIPTION
- [x] Adds the option to define files to watch per project so that they can automatically be watched upon opening - can be done via `.remote-sync.json` or the drop down configure.
- [x] Added/updated styles to show which files are being monitored
- [x] Adds option to toggle animation for monitored styles
- [x] Shortens the lengths of strings being monitored in notifications for windows devices
- [x] Updated readme with basic information about watching files