### PR TITLE
fixed bug with wrong paths for watchlist files

### DIFF
--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -215,7 +215,8 @@ class RemoteSync
   setupAutoFileWatch: (filesName,projectPath) ->
     _this = @
     setTimeout ->
-      filesName = filesName.replace(/\//g, '\\')
+      if process.platform == "win32"
+        filesName = filesName.replace(/\//g, '\\')
       fullpath = projectPath + filesName.replace /^\s+|\s+$/g, ""
       _this.monitorFile(fullpath,false,false)
     , 250

--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -215,6 +215,7 @@ class RemoteSync
   setupAutoFileWatch: (filesName,projectPath) ->
     _this = @
     setTimeout ->
+      filesName = filesName.replace(/\//g, '\\')
       fullpath = projectPath + filesName.replace /^\s+|\s+$/g, ""
       _this.monitorFile(fullpath,false,false)
     , 250


### PR DESCRIPTION
added rule to replace wrong forward slashes, with backslashes, in file
path - line 219