### PR TITLE
Add option to fold log panel on start up

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -69,6 +69,11 @@ module.exports =
       default: false
       title: 'Hide log panel after transferring'
       description: 'Hides the status view at the bottom of the window after the transfer operation is done'
+    foldLogPanel:
+      type: 'boolean'
+      default: false
+      title: 'Fold log panel by default'
+      description: 'Shows only one line in the status view'
     monitorFileAnimation:
       type: 'boolean'
       default: true

--- a/lib/Logger.coffee
+++ b/lib/Logger.coffee
@@ -23,6 +23,11 @@ class Logger
       className: className
 
     @panel.body.scrollTop(1e10)
+
+    if atom.config.get("remote-sync.foldLogPanel") and not @foldedPanel
+      @panel.toggle()
+      @foldedPanel = true
+
     msg
 
   log: (message) ->


### PR DESCRIPTION
I personally likes the log panel to show only a single line. So I click on the "fold" button every time I open Atom. This change will allow user to add option to fold the log panel by default.

See the screenshots:

I love this plugin. And I donated :)

<img width="768" alt="screen shot 2016-08-07 at 11 42 18 am" src="https://cloud.githubusercontent.com/assets/8622078/17464495/f3529c1c-5c94-11e6-8c43-ccb2e6b06152.png">
<img width="766" alt="screen shot 2016-08-07 at 11 42 24 am" src="https://cloud.githubusercontent.com/assets/8622078/17464497/f9f804c6-5c94-11e6-9a0d-0175c74abc0e.png">
<img width="324" alt="screen shot 2016-08-07 at 11 51 03 am" src="https://cloud.githubusercontent.com/assets/8622078/17464508/45da0fd8-5c95-11e6-889d-0e73945d9728.png">