### PR TITLE
Fix remote folder diff

### DIFF
--- a/lib/RemoteSync.coffee
+++ b/lib/RemoteSync.coffee
@@ -1,6 +1,7 @@
 path = require "path"
 fs = require "fs-plus"
 chokidar = require "chokidar"
+randomize = require "randomatic";
 
 exec = null
 minimatch = null
@@ -279,7 +280,7 @@ class RemoteSync
 
   diffFolder: (localPath)->
     os = require "os" if not os
-    targetPath = path.join os.tmpDir(), "remote-sync"
+    targetPath = path.join os.tmpDir(), "remote-sync", randomize('A0', 16)
     @downloadFolder localPath, targetPath, =>
       @diff localPath, targetPath
 


### PR DESCRIPTION
When doing a 2nd diff, folders still remained in the same temp dir causing conflicts
