### PR TITLE
Fix for #324 (uploadMirrors not working)

### DIFF
--- a/lib/UploadListener.coffee
+++ b/lib/UploadListener.coffee
@@ -19,7 +19,7 @@ class UploadListener
     if @queue.length()
       task = @queue._tasks.head
       while task
-       if task.data.localFilePath == localFilePath && task.data.action == action
+       if task.data.localFilePath == localFilePath && task.data.action == action && task.data.transport.settings.transport == transport.settings.transport && task.data.transport.settings.hostname == transport.settings.hostname && task.data.transport.settings.port == transport.settings.port && task.data.transport.settings.target == transport.settings.target
          task.data.discard = true
        task = task.next
 


### PR DESCRIPTION
Adds checks of the transport to make sure they match before discarding a queue task... otherwise the localFilePath and action always match and uploads to mirrors are seen as duplicate task items and discarded.
- Checks all transport settings to allow for mirrors with only small changes (e.g. different port only)