### PR TITLE
Fix for #388

### DIFF
--- a/menus/context.cson
+++ b/menus/context.cson
@@ -1,5 +1,5 @@
 'context-menu':
-  'atom-text-editor, .tree-view.full-menu .file':[
+  'atom-text-editor, .tree-view .file':[
     label: 'Remote Sync',
     submenu:[
       {label: 'Upload File', command: 'remote-sync:upload-file'}
@@ -10,7 +10,7 @@
     ]
   ]
 
-  '.tree-view.full-menu .header.list-item':[
+  '.tree-view .header.list-item':[
     label: 'Remote Sync',
     submenu:[
       {label: 'Configure', command: 'remote-sync:configure'}


### PR DESCRIPTION
[Atom 1.17.0] Missing configuration option when right clicking project folder or specific file