### PR TITLE
Add right click menu option back in the new update

### DIFF
--- a/menus/context.cson
+++ b/menus/context.cson
@@ -1,5 +1,5 @@
 'context-menu':
-  'atom-text-editor, .tree-view.full-menu .file':[
+  'atom-text-editor, .tool-panel.tree-view .file':[
     label: 'Remote Sync',
     submenu:[
       {label: 'Upload File', command: 'remote-sync:upload-file'}
@@ -10,7 +10,7 @@
     ]
   ]
 
-  '.tree-view.full-menu .header.list-item':[
+  '.tree-view.full-menu .header.list-item':[ to '.tool-panel.tree-view .header.list-item':[
     label: 'Remote Sync',
     submenu:[
       {label: 'Configure', command: 'remote-sync:configure'}


### PR DESCRIPTION
Atom v1.17.0 removed the context menu because it uses Docks now.

Issue https://github.com/yongkangchen/remote-sync/issues/388

Please don't merge this. I pasted the wrong thing.