### PR TITLE
Fixed CSS Selectors for ContextMenu

### DIFF
--- a/menus/context.cson
+++ b/menus/context.cson
@@ -1,5 +1,5 @@
 'context-menu':
-  'atom-text-editor, .tree-view .full-menu .file':[
+  '.entries.list-tree .file.entry.list-item':[
     label: 'Remote Sync',
     submenu:[
       {label: 'Upload File', command: 'remote-sync:upload-file'}
@@ -10,7 +10,7 @@
     ]
   ]
 
-  '.tree-view .full-menu .header.list-item':[
+  '.entries.list-tree .header.list-item, .entries.list-tree .directory.entry.list-nested-item.collapsed':[
     label: 'Remote Sync',
     submenu:[
       {label: 'Configure', command: 'remote-sync:configure'}


### PR DESCRIPTION
Issue materialised circa Atom update 1.19.7 - Not to be confused with similar issue in Atom 1.17.0...