### PR TITLE
right click menu not appearing problem fix

### DIFF
--- a/menus/context.cson
+++ b/menus/context.cson
@@ -1,5 +1,5 @@
 'context-menu':
-  'atom-text-editor, .tree-view .full-menu .file':[
+  'atom-text-editor, .tool-panel.tree-view .file':[
     label: 'Remote Sync',
     submenu:[
       {label: 'Upload File', command: 'remote-sync:upload-file'}
@@ -10,7 +10,7 @@
     ]
   ]
 
-  '.tree-view .full-menu .header.list-item':[
+  '.tool-panel.tree-view .header.list-item':[
     label: 'Remote Sync',
     submenu:[
       {label: 'Configure', command: 'remote-sync:configure'}


### PR DESCRIPTION
Because of the selector changes in recent updates of Atom Core, quick fix for the problem of remote-sync menu not showing when right-clicking the project folder.