### PR TITLE
Feature request #341: add a keepalive configuration for both FTP and SCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The `.remote-sync.json` in your project root will use these options:
 | `source`          | String   | ""                              | Source directory relative to project root                                                      |
 | `ignore`          | Array    | [".remote-sync.json",".git/**"] | Array of [minimatch](https://github.com/isaacs/minimatch) patterns of files to ignore          |
 | `watch`           | Array    | []                              | Array of files (relative to project root - starting with "/") to watch for changes             |
+| `keepalive`       | Integer  | 0                               | Number of seconds to wait between two keepalive                                                |
 | `uploadMirrors`   | Array    | []                              | Transport mirror config array when upload                                                      |
 | `uploadOnSave`    | Boolean  | false                           | Whether or not to upload the current file when saved                                           |
 | `saveOnUpload`    | Boolean  | false                           | Whether or not to save a modified file before uploading                                        |
@@ -122,7 +123,8 @@ The `.remote-sync.json` in your project root will use these options:
   "watch":[
     "/css/styles.css",
     "/index.html"
-  ]
+  ],
+  "keepalive": 60
 }
 ```
 
@@ -164,7 +166,8 @@ The `.remote-sync.json` in your project root will use these options:
   "watch":[
     "/css/styles.css",
     "/index.html"
-  ]
+  ],
+  "keepalive": 60
 }
 ```
 

--- a/lib/transports/FtpTransport.coffee
+++ b/lib/transports/FtpTransport.coffee
@@ -114,7 +114,7 @@ class FtpTransport
       directory(targetPath)
 
   _getConnection: (callback) ->
-    {hostname, port, username, password, secure} = @settings
+    {hostname, port, username, password, secure, keepalive} = @settings
 
     if @connection
       return callback null, @connection
@@ -144,5 +144,6 @@ class FtpTransport
       user: username
       password: password
       secure: secure
+	  keepalive: keepalive * 1000 || 0
 
     @connection = connection

--- a/lib/transports/ScpTransport.coffee
+++ b/lib/transports/ScpTransport.coffee
@@ -131,7 +131,7 @@ class ScpTransport
           callback null, files
 
   _getConnection: (callback) ->
-    {hostname, port, username, password, keyfile, useAgent, passphrase, readyTimeout} = @settings
+    {hostname, port, username, password, keyfile, useAgent, passphrase, readyTimeout, keepalive} = @settings
 
     if @connection
       return callback null, @connection
@@ -185,5 +185,6 @@ class ScpTransport
       passphrase: passphrase
       readyTimeout: readyTimeout
       agent: agent
+	  keepaliveInterval: keepalive * 1000 || 0
 
     @connection = connection

--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -46,6 +46,9 @@ class ConfigView extends View
       @div class: 'block', outlet: 'ftpPasswordBlock', style: 'display:none', =>
         @label 'Password'
 
+      @label 'Keepalive'
+      @subview 'keepalive', new TextEditorView(mini: true, placeholderText: "Interval to send keepalive requests in seconds. Leave blank to disable")
+
       @label 'Watch automatically'
       @subview 'watch', new TextEditorView(mini: true, placeholderText: "Files that will be automatically watched on project open")
 
@@ -133,6 +136,8 @@ class ConfigView extends View
       @host.useAgent = true
     else
       @host.useAgent = undefined
+
+    @host.keepalive = parseInt(@host.keepalive) || 0
 
     @host.saveJSON()
     @close()


### PR DESCRIPTION
Hi,

I'm using this package at work in order to deploy what I write to our test servers. However like most companies out there, there is a nasty firewall cutting the line if there is no activity for a certain amount of time.
In order to avoid this disconnection, keepalive packets can be sent. Lucky for me the base node modules already had this option :) I just added support for this option, defaulting it to 0 and documented the new setting.

This solves issues #341 and #355.