### PR TITLE
Add .ssh directory to default ignore paths

### DIFF
--- a/lib/view/host-view.coffee
+++ b/lib/view/host-view.coffee
@@ -22,7 +22,7 @@ class ConfigView extends View
       @subview 'target', new TextEditorView(mini: true)
 
       @label 'Ignore Paths'
-      @subview 'ignore', new TextEditorView(mini: true, placeholderText: "Default: .remote-sync.json, .git/**")
+      @subview 'ignore', new TextEditorView(mini: true, placeholderText: "Default: .remote-sync.json, .git/**, .ssh/**")
 
       @label 'Username'
       @subview 'username', new TextEditorView(mini: true)


### PR DESCRIPTION
Many people use remote-sync for a home directory and this change avoids having .ssh directories downloaded since it contains sensitive SSH keys. I understand if this PR gets denied since not everyone versions a home directory, but I feel it's a small amount of additional work that can help a lot of people.